### PR TITLE
Add image upload functionality to Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,19 @@
 import streamlit as st
 
-st.title("🎈 My new app")
+st.title("🎈 Meine neue App")
 st.write(
-    "Let's start building! For help and inspiration, head over to [docs.streamlit.io](https://docs.streamlit.io/)."
+    "Lade ein Bild hoch, um es direkt in der App anzusehen. Für Hilfe und Inspiration geht es zu "
+    "[docs.streamlit.io](https://docs.streamlit.io/)."
 )
+
+uploaded_file = st.file_uploader(
+    "Bild auswählen",
+    type=["png", "jpg", "jpeg", "gif", "bmp", "webp"],
+    help="Unterstützte Formate: PNG, JPG, JPEG, GIF, BMP und WEBP.",
+)
+
+if uploaded_file is not None:
+    st.success(f"Datei '{uploaded_file.name}' erfolgreich hochgeladen!")
+    st.image(uploaded_file, caption=uploaded_file.name, use_container_width=True)
+else:
+    st.info("Bitte wähle ein Bild aus, das angezeigt werden soll.")


### PR DESCRIPTION
## Summary
- update the app copy to explain the new image upload functionality
- add a file uploader that accepts common image formats
- display a success message and preview of the uploaded image

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd7a2169f0832ebf15c46327823028